### PR TITLE
Update BaseIndexStore.java   fix NullPointerException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -163,7 +163,7 @@ public abstract class BaseIndexStore implements IndexStore {
 
         @Override
         public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
-            if (isExpirable()) {
+            if (map !=null && isExpirable()) {
                 return new ExpirationAwareHashMapDelegate(map);
             }
             return map;


### PR DESCRIPTION
when copyOn == IndexCopyBehavior.NEVER.   [BaseIndexStore.resultCopyFunctor] is PassThroughFunctor
when index query result is null.  the null value will be passed to ExpirationAwareHashMapDelegate. so it`s delegateMap is null
then AbstractIndex line:186 .   variable [result]  is Set which contains the ExpirationAwareHashMapDelegate whose delegateMap is null
the size() will throw NullPointerException.
then scan the whole partition